### PR TITLE
add Shinhan Card type

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 * Maestro
 * Forbrugsforeningen
 * Dankort
+* Shinhan
 
 Visa Electron cards will validate and match as regular Visa cards.
 

--- a/src/types.js
+++ b/src/types.js
@@ -60,3 +60,9 @@ exports.unionPay = new Type('UnionPay', {
   groupPattern: group19,
   luhn: false
 })
+
+exports.shinhan = new Type('Shinhan', {
+  pattern: /^9\d{15,18}$/,
+  eagerPattern: /^9/,
+  groupPattern: group19
+})

--- a/test.js
+++ b/test.js
@@ -189,6 +189,32 @@ test('UnionPay', function (t) {
   t.end()
 })
 
+test('Shinhan', function (t) {
+  var shinhan = types.shinhan
+  t.ok(shinhan.test('9123456789123456'), 'normal')
+  t.ok(shinhan.test('9123456789123456000'), '19 digit')
+  t.deepEqual(shinhan.group('9123456789123456'), [
+    '9123',
+    '4567',
+    '8912',
+    '3456'
+  ], 'group full number')
+  t.deepEqual(shinhan.group('9123456789123456000'), [
+    '9123',
+    '4567',
+    '8912',
+    '3456',
+    '000'
+  ], 'group 19 digit')
+  eagerType(t, shinhan, [
+    '9123',
+    '912',
+    '91',
+    '9'
+  ])
+  t.end()
+})
+
 test('find', function (t) {
   var visa = find(function (type) {
     return type.name === 'Visa'


### PR DESCRIPTION
Korean Shinhan Bank has its own credit card type [Shinhan Card](http://eng.shinhancard.com/contents/cards/check/checkKonepass.jsp).

It has exactly the same number format as Visa and MasterCard excepts that it starts with 9.