### PR TITLE
Add Meeza patterns

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,7 @@ Card data can be required individually by [type](types/). The main module includ
 The main types in this library have unique patterns that map to major card networks. In some locales, companies issue co-branded with other card networks within the major partner's BIN range. This library includes these types as modules but _does not_ include co-branded types in the main export. Custom types include:
 
 * Mada
+* Meeza
 
 Similar to [using custom types](#usage), you can prepend optional types to the main list. Cards that previously matched as a major issuer will instead match the custom type if applicable.
 

--- a/test/meeza.js
+++ b/test/meeza.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const test = require('tape')
+const eagerType = require('./eager-type')
+const meeza = require('../types/meeza')
+
+test('Meeza', function (t) {
+  t.ok(meeza.test('5078036246600381'), 'normal')
+  eagerType(t, meeza, [
+    '507803'
+  ])
+  t.end()
+})

--- a/types/meeza.d.ts
+++ b/types/meeza.d.ts
@@ -1,0 +1,3 @@
+import { ICardType } from "../type";
+declare const CardType: ICardType;
+export default CardType;

--- a/types/meeza.js
+++ b/types/meeza.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const Type = require('../type')
+
+module.exports = Type({
+  name: 'Meeza',
+  digits: 16,
+  pattern: /^5078(03|09|10|11)\d{10}$/,
+  eagerPattern: /^5078(03|09|10|11)/
+})


### PR DESCRIPTION
We use your lib in Egypt and it would be handy to have Meeza card type in it (https://meeza-eg.com/).
Unfortunately, i could not find any official Meeza documentation and only rely on communication with our partner:

![noon-about-meeza](https://user-images.githubusercontent.com/2732523/171428571-6958add2-2e87-457e-be3f-3c6536ed2705.jpg)
